### PR TITLE
Load config for relays, self, receiver, and listen

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ CLI for [Nostr](https://github.com/nostr-protocol/nostr)
 **Show nostr version**
 ```bash
 ❯ nostr --version
-nostr, version 0.5.0
+nostr, version 0.6.0
 ```
 
 **Generate a key pair**
@@ -57,7 +57,6 @@ nostr, version 0.5.0
 **Receive message(s)**
 ```
 ❯ nostr message receive -p <the npub key to receive the messages>
-Hello, publishing a message through nostr CLI.
 {
   "Public key": "npub1rfs...c9tg",
   "Events": [
@@ -67,6 +66,77 @@ Hello, publishing a message through nostr CLI.
   "Notices": []
 }
 ```
+
+### Simplify the CLI with a config file: `config.hcl`:
+```config.hcl
+nostr {
+    relays = [
+        "wss://nostr-pub.wellorder.net",
+        "wss://relay.damus.io",
+    ]
+
+    self {
+        name = "Ali Kiten"
+
+        nsec = "nsec1jqa...fcjd"
+    }
+
+    receiver "Ray" {
+        name = "Ray Nostr"
+
+        npub = "npub1q75...c62u"
+    }
+
+    listen "jon" {
+        name = "Jonathon Gate"
+
+        npub = "npub1s9c...a9je"
+    }
+
+    listen "jack" {
+        name = "Jack Hoose"
+
+        npub = "npub1s9c...a9je"
+    }
+}
+```
+By default, nostr will search the current path `config.hcl` first, then `${HOME}/.nostr/config.hcl`.
+
+You can also manually specify the config file by:
+```
+❯ nostr message -c <path/to/the/config.hcl> receive -i jack
+```
+Once setting up the config file, the above message commands could be much simpler:
+
+**Publish a message with config file**
+```bash
+❯ nostr message publish -m "Hello, publishing a message through nostr CLI."
+{
+  "Message": "Hello, publishing a message through nostr CLI."
+}
+```
+
+**Send an encryped direct message**
+```bash
+❯ nostr message send -m "Hello, sending an encryped direct message" -i <the receiver identifier, like "Ray" in the above sample>
+{
+  "Message": "Hello, sending an encryped direct message"
+}
+```
+
+**Receive message(s)**
+```
+❯ nostr message receive -i <the listen indentifier in the above sample config file>
+{
+  "Public key": "npub1rfs...c9tg",
+  "Events": [
+    "Hello, publishing a message through nostr CLI.",
+    "Hello, sending an encryped direct message"
+  ],
+  "Notices": []
+}
+```
+
 
 
 ## Development & Test

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,10 @@
 ### TODO
 
-- [] Load config for some items
-- [] Support metadata
+- [x] Load config for relays, self, receiver, and listen
+- [] Support to set metadata
 - [x] Publish nostrpy to pypi
 - [x] Update README with CI/CD
 - [] Update README with package information
-- [] Add unit test for CLI
+- [x] Add unit test for CLI
 
 Feel free to add issue(s), add PR(s) for TODO

--- a/nostr/commands/config.py
+++ b/nostr/commands/config.py
@@ -1,0 +1,53 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import hcl2
+
+
+@dataclass
+class Config:
+    filename: str = "config.hcl"
+
+    @classmethod
+    def locate(cls) -> Path:
+        """
+        Locate config path
+
+        # Search paths:
+        # 1. ${CURRENT_PATH}/config.hcl
+        # 2. ${HOME}/.nostr/config.hcl
+        """
+        fullpath = Path.cwd().joinpath(cls.filename)
+        if fullpath.exists():
+            return fullpath
+        fullpath = Path.home().joinpath('.nostr', cls.filename)
+        if fullpath.exists():
+            return fullpath
+
+        return None
+
+    @classmethod
+    def load(cls, filename: str = None) -> dict:
+        """
+        Load the config file
+        """
+        filename = filename or cls.locate()
+        if filename:
+            with open(filename) as file:
+                return hcl2.load(file)
+        return {}
+
+    @staticmethod
+    def dump(content: dict = None) -> str:
+        """
+        Dump the config content
+        """
+        if content:
+            return json.dumps(content, indent=2)
+
+
+if __name__ == "__main__":
+    print(
+        Config.dump(Config.load(Path.cwd().joinpath('test', 'fixtures', 'config.hcl')))
+    )

--- a/nostr/commands/config.py
+++ b/nostr/commands/config.py
@@ -18,12 +18,14 @@ class Config:
         # 1. ${CURRENT_PATH}/config.hcl
         # 2. ${HOME}/.nostr/config.hcl
         """
-        fullpath = Path.cwd().joinpath(cls.filename)
-        if fullpath.exists():
-            return fullpath
-        fullpath = Path.home().joinpath('.nostr', cls.filename)
-        if fullpath.exists():
-            return fullpath
+        paths = [
+            Path.cwd().joinpath(cls.filename),
+            Path.home().joinpath('.nostr', cls.filename),
+        ]
+
+        for path in paths:
+            if path.exists():
+                return path
 
         return None
 
@@ -45,9 +47,3 @@ class Config:
         """
         if content:
             return json.dumps(content, indent=2)
-
-
-if __name__ == "__main__":
-    print(
-        Config.dump(Config.load(Path.cwd().joinpath('test', 'fixtures', 'config.hcl')))
-    )

--- a/nostr/commands/message.py
+++ b/nostr/commands/message.py
@@ -4,35 +4,89 @@ import uuid
 
 import click
 
+from nostr.commands.config import Config
 from nostr.event import EncryptedDirectMessage, Event, EventKind
 from nostr.filter import Filter, Filters
 from nostr.key import PrivateKey, PublicKey
 from nostr.message_type import ClientMessageType
 from nostr.relay_manager import RelayManager
+from nostr.utils import dict2obj
 
 
 @click.group()
-def cli():
+@click.option("-c", "--config", required=False, type=str, help="Config file")
+@click.pass_context
+def cli(ctx, config: str = None):
     """Command related to message(s)."""
+    ctx.ensure_object(dict)
+
+    # Set default relays
+    ctx.obj['relays'] = ["wss://nostr-pub.wellorder.net", "wss://relay.damus.io"]
+
+    config = Config.load(config)
+    if config:
+        try:
+            relays = dict2obj(config).nostr[0].relays
+            if relays:
+                ctx.obj['relays'] = relays
+        except AttributeError:
+            pass
+
+        try:
+            influencers = dict2obj(config).nostr[0].listen
+            if influencers:
+                ctx.obj['influencers'] = influencers
+        except AttributeError:
+            pass
+
+        try:
+            ctx.obj['self'] = dict2obj(config).nostr[0].self[0]
+        except AttributeError:
+            pass
+
+        try:
+            receivers = dict2obj(config).nostr[0].receiver
+            if receivers:
+                ctx.obj['receivers'] = receivers
+        except AttributeError:
+            pass
 
 
 @cli.command()
-@click.option("-p", "--pub-key", "npub", required=True, type=str)
+@click.option("-i", "--identifier", required=False, type=str)
+@click.option("-p", "--pub-key", "npub", required=False, type=str)
 @click.option("-l", "--limit", "limit", type=int, default=10)
 @click.option("--sleep", "sleep", type=int, default=2)
-def receive(npub: str, limit: int = 10, sleep: int = 2):
+@click.pass_context
+def receive(ctx: dict, identifier: str, npub: str, limit: int = 10, sleep: int = 2):
     """Receives messages from npub address."""
-    author = PublicKey.from_npub(npub)
+    npubs = [npub] if npub else []
+    if identifier:
+        for influencer in ctx.obj.get('influencers', []):
+            if hasattr(influencer, identifier):
+                try:
+                    npubs.append(getattr(influencer, identifier).npub)
+                except AttributeError:
+                    pass
+
+    if not npubs:
+        print(
+            "Please input `npub`; and/or",
+            "specify listen `identifier` by creating the config file",
+        )
+        return 1
+
+    authors = [PublicKey.from_npub(npub).hex() for npub in npubs]
     filters = Filters(
-        [Filter(authors=[author.hex()], kinds=[EventKind.TEXT_NOTE], limit=limit)]
+        [Filter(authors=authors, kinds=[EventKind.TEXT_NOTE], limit=limit)]
     )
     subscription_id = uuid.uuid1().hex
     request = [ClientMessageType.REQUEST, subscription_id]
     request.extend(filters.to_json_array())
 
     relay_manager = RelayManager()
-    relay_manager.add_relay("wss://nostr-pub.wellorder.net")
-    relay_manager.add_relay("wss://relay.damus.io")
+    for relay in ctx.obj['relays']:
+        relay_manager.add_relay(relay)
     relay_manager.add_subscription(subscription_id, filters)
 
     def get_events(relay_manager):
@@ -59,17 +113,30 @@ def receive(npub: str, limit: int = 10, sleep: int = 2):
         notices = get_notices(relay_manager=relay_manager)
         click.echo(
             json.dumps(
-                {"Public key": npub, "Events": events, "Notices": notices}, indent=2
+                {"Public key(s)": npubs, "Events": events, "Notices": notices}, indent=2
             )
         )
 
 
 @cli.command()
-@click.option("-s", "--sec-key", "nsec", required=True, type=str)
+@click.option("-s", "--sec-key", "nsec", required=False, type=str)
 @click.option("-m", "--message", "message", type=str)
 @click.option("--sleep", "sleep", type=int, default=2)
-def publish(nsec: str, message: str, sleep: int = 2):
+@click.pass_context
+def publish(ctx: dict, nsec: str, message: str, sleep: int = 2):
     """Sends a message."""
+    if not nsec and ctx.obj.get('self'):
+        try:
+            nsec = ctx.obj.get('self').nsec
+        except AttributeError:
+            pass
+
+    if not nsec:
+        print(
+            "Please input `nsec`; and/or",
+            "set `nsec`, under `self` block in config file",
+        )
+        return 1
     private_key = PrivateKey.from_nsec(nsec)
     event = Event(content=message, public_key=private_key.public_key.hex())
     event.sign(private_key.hex())
@@ -77,22 +144,62 @@ def publish(nsec: str, message: str, sleep: int = 2):
     msg = json.dumps([ClientMessageType.EVENT, event.to_dict()])
 
     relay_manager = RelayManager()
-    relay_manager.add_relay("wss://nostr-pub.wellorder.net")
-    relay_manager.add_relay("wss://relay.damus.io")
+    for relay in ctx.obj['relays']:
+        relay_manager.add_relay(relay)
     with relay_manager:
         time.sleep(sleep)  # allow the connections to open
         relay_manager.publish_message(msg)
 
     click.echo(json.dumps({"Message": message}, indent=2))
+    return 0
 
 
 @cli.command()
-@click.option("-s", "--sec-key", "nsec", required=True, type=str)
+@click.option("-s", "--sec-key", "nsec", required=False, type=str)
 @click.option("-m", "--message", "message", type=str)
-@click.option("-p", "--pub-key", "receiver_npub", required=True, type=str)
+@click.option("-i", "--identifier", required=False, type=str)
+@click.option("-p", "--pub-key", "receiver_npub", required=False, type=str)
 @click.option("--sleep", "sleep", type=int, default=2)
-def send(nsec: str, message: str, receiver_npub: str, sleep: int = 2):
+@click.pass_context
+def send(
+    ctx: dict,
+    nsec: str,
+    message: str,
+    identifier: str,
+    receiver_npub: str,
+    sleep: int = 2,
+):
     """Sends a encryped direct message."""
+    if not nsec and ctx.obj.get('self'):
+        try:
+            nsec = ctx.obj.get('self').nsec
+        except AttributeError:
+            pass
+
+    if not nsec:
+        print(
+            "Please input `nsec`; and/or",
+            "set `nsec`, under `self` block in config file",
+        )
+        return 1
+
+    receiver_npub = receiver_npub or None
+    if not receiver_npub and identifier:
+        for receiver in ctx.obj.get('receivers', []):
+            if hasattr(receiver, identifier):
+                try:
+                    receiver_npub = getattr(receiver, identifier).npub
+                except AttributeError:
+                    pass
+
+    if not receiver_npub:
+        print(
+            "Please input `receiver_npub`; and/or",
+            "specify `identifier`, which should be found",
+            "under `receiver` block in config file",
+        )
+        return 1
+
     private_key = PrivateKey.from_nsec(nsec)
     recipient_pubkey = PublicKey.from_npub(receiver_npub)
     direct_message = EncryptedDirectMessage(
@@ -106,11 +213,12 @@ def send(nsec: str, message: str, receiver_npub: str, sleep: int = 2):
     direct_message.sign(private_key.hex())
 
     relay_manager = RelayManager()
-    relay_manager.add_relay("wss://nostr-pub.wellorder.net")
-    relay_manager.add_relay("wss://relay.damus.io")
+    for relay in ctx.obj['relays']:
+        relay_manager.add_relay(relay)
 
     with relay_manager:
         time.sleep(sleep)  # allow the connections to open
         relay_manager.publish_event(direct_message)
 
     click.echo(json.dumps({"Message": message}, indent=2))
+    return 0

--- a/nostr/commands/message.py
+++ b/nostr/commands/message.py
@@ -56,7 +56,7 @@ def cli(ctx, config: str = None):
 @click.option("-i", "--identifier", required=False, type=str)
 @click.option("-p", "--pub-key", "npub", required=False, type=str)
 @click.option("-l", "--limit", "limit", type=int, default=10)
-@click.option("--sleep", "sleep", type=int, default=2)
+@click.option("-s", "--sleep", "sleep", type=int, default=2)
 @click.pass_context
 def receive(ctx: dict, identifier: str, npub: str, limit: int = 10, sleep: int = 2):
     """Receives messages from npub address."""
@@ -116,6 +116,7 @@ def receive(ctx: dict, identifier: str, npub: str, limit: int = 10, sleep: int =
                 {"Public key(s)": npubs, "Events": events, "Notices": notices}, indent=2
             )
         )
+    return 0
 
 
 @cli.command()

--- a/nostr/sample/config.hcl
+++ b/nostr/sample/config.hcl
@@ -1,0 +1,30 @@
+nostr {
+    relays = [
+        "wss://nostr-pub.wellorder.net",
+        "wss://relay.damus.io",
+    ]
+
+    self {
+        name = "Ali Kiten"
+
+        nsec = "nsec1jqaxtwk4tymddju9dmn58tdxgwgl5ck23gg847fla9cyuslxklrq86fcjd"
+    }
+
+    receiver "Ray" {
+        name = "Ray Nostr"
+
+        npub = "npub1q75f9j9w4zzjf5978eh6ym3pewvrnq5p7tdpaf9anzqmvgkgz8ys22c62u"
+    }
+
+    listen "jon" {
+        name = "Jonathon Gate"
+
+        npub = "npub1s9c53smfq925qx6fgkqgw8as2e99l2hmj32gz0hjjhe8q67fxdvs3ga9je"
+    }
+
+    listen "jack" {
+        name = "Jack Hoose"
+
+        npub = "npub1s9c53smfq925qx6fgkqgw8as2e99l2hmj32gz0hjjhe8q67fxdvs3ga9je"
+    }
+}

--- a/nostr/utils.py
+++ b/nostr/utils.py
@@ -1,0 +1,10 @@
+import json
+
+
+class obj:
+    def __init__(self, dict_):
+        self.__dict__.update(dict_)
+
+
+def dict2obj(d):
+    return json.loads(json.dumps(d), object_hook=obj)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "websocket-client>=1.4.2",
     "click>=8.1.3",
     "click-aliases>=1.0.1",
+    "python-hcl2>=4.3.0",
 ]
 license = {file = "LICENSE"}
 classifiers=[
@@ -32,7 +33,8 @@ write_to = "nostr/_version.py"
 [project.optional-dependencies]
 test = [
   "pytest >=7.2.0",
-  "pytest-cov[all]"
+  "pytest-cov[all]",
+  "pre-commit >=3.1.0",
 ]
 
 [project.scripts]

--- a/test/commands/test_cli_message.py
+++ b/test/commands/test_cli_message.py
@@ -1,58 +1,88 @@
 import json
 import unittest
-from unittest.mock import ANY
+from unittest import mock
+from unittest.mock import ANY, MagicMock, patch
 
 from click.testing import CliRunner
 
 from nostr.commands.message import cli
+from nostr.event import Event
+from nostr.message_pool import EventMessage
 
 
 class TestCLIMessage(unittest.TestCase):
-    def test_publish(self):
+    @patch('nostr.commands.message.RelayManager', autospec=True)
+    def test_publish(self, mock_relay_manager):
         # GIVEN
         nsec = "nsec1lrjqzalcev9ard0274pu8ynwx0xzzexh56sfn0c97rumh8f2tfcqd3lf8h"
         message = "Hello nostr world!"
         runner = CliRunner()
 
+        mock_manager = MagicMock()
+        mock_relay_manager.return_value = mock_manager
+        mock_manager.__enter__.return_value = mock_manager
+        mock_manager.add_relay.return_value = None
+
         # WHEN
         result = runner.invoke(
-            cli, ['publish', '-s', nsec, '-m', message], catch_exceptions=False
+            cli,
+            ['publish', '-s', nsec, '-m', message, '--sleep', 0],
+            catch_exceptions=False,
         )
 
         # THEN
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(json.loads(result.output), {"Message": message})
+        mock_manager.add_relay.assert_has_calls([mock.call(ANY), mock.call(ANY)])
+        mock_manager.publish_message.assert_called()
 
-    def test_send(self):
+    @patch('nostr.commands.message.RelayManager', autospec=True)
+    def test_send(self, mock_relay_manager):
         # GIVEN
         nsec = "nsec1jqaxtwk4tymddju9dmn58tdxgwgl5ck23gg847fla9cyuslxklrq86fcjd"
         npub = "npub1mg2nzunrsk9df94zr3uudhzltnu6lzq2muax09xmhu5gxxrvnkqsvpjg3p"
         message = "Hello nostr world!"
         runner = CliRunner()
 
+        mock_manager = MagicMock()
+        mock_relay_manager.return_value = mock_manager
+        mock_manager.__enter__.return_value = mock_manager
+        mock_manager.add_relay.return_value = None
+
         # WHEN
         result = runner.invoke(
             cli,
-            ['send', '-s', nsec, '-m', message, '-p', npub],
+            ['send', '-s', nsec, '-m', message, '-p', npub, '--sleep', 0],
         )
 
         # THEN
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(json.loads(result.output), {"Message": message})
+        mock_manager.add_relay.assert_has_calls([mock.call(ANY), mock.call(ANY)])
+        mock_manager.publish_event.assert_called()
 
-    def test_receive(self):
+    @patch('nostr.commands.message.RelayManager', autospec=True)
+    def test_receive(self, mock_relay_manager):
         # GIVEN
         npub = "npub1mg2nzunrsk9df94zr3uudhzltnu6lzq2muax09xmhu5gxxrvnkqsvpjg3p"
         runner = CliRunner()
 
+        mock_manager = MagicMock()
+        mock_relay_manager.return_value = mock_manager
+        mock_manager.__enter__.return_value = mock_manager
+        mock_manager.add_relay.return_value = None
+
+        mock_manager.message_pool.has_events.side_effect = [True, False]
+        mock_manager.message_pool.get_event.return_value = EventMessage(
+            Event(content="any"), subscription_id=123, url="wss://any.relay"
+        )
+
+        mock_manager.message_pool.has_notices.return_value = False
+
         # WHEN
         result = runner.invoke(
             cli,
-            [
-                'receive',
-                '-p',
-                npub,
-            ],
+            ['receive', '-p', npub, '-s', 0],
         )
 
         # THEN
@@ -61,3 +91,9 @@ class TestCLIMessage(unittest.TestCase):
             json.loads(result.output),
             {"Public key(s)": [npub], "Events": ANY, "Notices": ANY},
         )
+        mock_manager.add_relay.assert_has_calls([mock.call(ANY), mock.call(ANY)])
+        mock_manager.publish_message.assert_called()
+        mock_manager.message_pool.has_events.assert_called()
+        mock_manager.message_pool.get_event.assert_called()
+        mock_manager.message_pool.has_notices.assert_called()
+        mock_manager.message_pool.get_notice.assert_not_called()

--- a/test/commands/test_cli_message_with_config.py
+++ b/test/commands/test_cli_message_with_config.py
@@ -1,12 +1,15 @@
 import json
 import unittest
 from pathlib import Path
-from unittest.mock import ANY
+from unittest import mock
+from unittest.mock import ANY, MagicMock, patch
 
 import hcl2
 from click.testing import CliRunner
 
 from nostr.commands.message import cli
+from nostr.event import Event
+from nostr.message_pool import EventMessage
 
 
 class TestCLIMessageWithConfig(unittest.TestCase):
@@ -15,51 +18,74 @@ class TestCLIMessageWithConfig(unittest.TestCase):
         with open(self.config_file) as file:
             self.config = hcl2.load(file)
 
-    def test_publish(self):
+    @patch('nostr.commands.message.RelayManager', autospec=True)
+    def test_publish(self, mock_relay_manager):
         # GIVEN
         message = "Hello nostr world!!"
         runner = CliRunner()
 
+        mock_manager = MagicMock()
+        mock_relay_manager.return_value = mock_manager
+        mock_manager.__enter__.return_value = mock_manager
+        mock_manager.add_relay.return_value = None
+
         # WHEN
         result = runner.invoke(
             cli,
-            ['-c', self.config_file, 'publish', '-m', message],
+            ['-c', self.config_file, 'publish', '-m', message, '--sleep', 0],
             catch_exceptions=False,
         )
 
         # THEN
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(json.loads(result.output), {"Message": message})
+        mock_manager.add_relay.assert_has_calls([mock.call(ANY), mock.call(ANY)])
+        mock_manager.publish_message.assert_called()
 
-    def test_send(self):
+    @patch('nostr.commands.message.RelayManager', autospec=True)
+    def test_send(self, mock_relay_manager):
         # GIVEN
         message = "Hello nostr world!!"
         runner = CliRunner()
 
+        mock_manager = MagicMock()
+        mock_relay_manager.return_value = mock_manager
+        mock_manager.__enter__.return_value = mock_manager
+        mock_manager.add_relay.return_value = None
+
         # WHEN
         result = runner.invoke(
             cli,
-            ['-c', self.config_file, 'send', '-m', message, '-i', 'Ray'],
+            ['-c', self.config_file, 'send', '-m', message, '-i', 'Ray', '--sleep', 0],
         )
 
         # THEN
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(json.loads(result.output), {"Message": message})
+        mock_manager.add_relay.assert_has_calls([mock.call(ANY), mock.call(ANY)])
+        mock_manager.publish_event.assert_called()
 
-    def test_receive(self):
+    @patch('nostr.commands.message.RelayManager', autospec=True)
+    def test_receive(self, mock_relay_manager):
         # GIVEN
         runner = CliRunner()
+
+        mock_manager = MagicMock()
+        mock_relay_manager.return_value = mock_manager
+        mock_manager.__enter__.return_value = mock_manager
+        mock_manager.add_relay.return_value = None
+
+        mock_manager.message_pool.has_events.side_effect = [True, False]
+        mock_manager.message_pool.get_event.return_value = EventMessage(
+            Event(content="any"), subscription_id=123, url="wss://any.relay"
+        )
+
+        mock_manager.message_pool.has_notices.return_value = False
 
         # WHEN
         result = runner.invoke(
             cli,
-            [
-                '-c',
-                self.config_file,
-                'receive',
-                '-i',
-                'jon',
-            ],
+            ['-c', self.config_file, 'receive', '-i', 'jon', '-s', 0],
         )
 
         # THEN
@@ -72,3 +98,9 @@ class TestCLIMessageWithConfig(unittest.TestCase):
                 "Notices": ANY,
             },
         )
+        mock_manager.add_relay.assert_has_calls([mock.call(ANY), mock.call(ANY)])
+        mock_manager.publish_message.assert_called()
+        mock_manager.message_pool.has_events.assert_called()
+        mock_manager.message_pool.get_event.assert_called()
+        mock_manager.message_pool.has_notices.assert_called()
+        mock_manager.message_pool.get_notice.assert_not_called()

--- a/test/commands/test_config.py
+++ b/test/commands/test_config.py
@@ -1,0 +1,84 @@
+import shutil
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, mock_open, patch
+
+from nostr.commands.config import Config
+
+
+class TestConfig(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.filename = 'config.hcl'
+
+        cls.home_directory = Path.home().joinpath('.nostr')
+        cls.home_directory.mkdir(exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        if Path.cwd().joinpath(cls.filename).exists():
+            Path.cwd().joinpath(cls.filename).unlink()
+        if cls.home_directory.exists():
+            shutil.rmtree(cls.home_directory, ignore_errors=True)
+
+    def test_existing_file_in_cwd(self):
+        # GIVEN
+        Path.cwd().joinpath(self.filename).touch()
+        expected_path = Path.cwd().joinpath(self.filename)
+        # WHEN
+        actual_path = Config.locate()
+        # THEN
+        self.assertEqual(expected_path, actual_path)
+
+    def test_existing_file_in_home_directory(self):
+        # GIVEN
+        Path.cwd().joinpath(self.filename).unlink(missing_ok=True)
+        self.home_directory.joinpath(self.filename).touch()
+        expected_path = self.home_directory.joinpath(self.filename)
+        # WHEN
+        actual_path = Config.locate()
+        # THEN
+        self.assertEqual(expected_path, actual_path)
+
+    def test_file_not_found(self):
+        # GIVEN
+        Path.cwd().joinpath(self.filename).unlink(missing_ok=True)
+        shutil.rmtree(self.home_directory, ignore_errors=True)
+        # WHEN
+        actual = Config.locate()
+        # THEN
+        self.assertEqual(None, actual)
+
+    @patch('builtins.open', new_callable=mock_open, read_data='key = "value"')
+    def test_load_valid_file(self, mock_file):
+        # Mock the locate method to return a valid file path
+        Config.locate = Mock()
+        Config.locate.return_value = "test.hcl"
+        config = Config.load()
+        mock_file.assert_called_once_with("test.hcl")
+        self.assertEqual(config, {'key': 'value'})
+
+    @patch('builtins.open', new_callable=mock_open, read_data='key = "value"')
+    def test_load_valid_file_with_param(self, mock_file):
+        # Mock the locate method to return a valid file path
+        config = Config.load("test.hcl")
+        mock_file.assert_called_once_with("test.hcl")
+        self.assertEqual(config, {'key': 'value'})
+
+    @patch('builtins.open', side_effect=FileNotFoundError)
+    def test_load_file_not_found(self, mock_file):
+        # Mock the locate method to return None
+        Config.locate = Mock()
+        Config.locate.return_value = None
+        config = Config.load()
+        self.assertEqual(config, {})
+
+    def test_dump_with_content(self):
+        content = {"key": "value"}
+        result = Config.dump(content)
+        expected_result = "{\n  \"key\": \"value\"\n}"
+        self.assertEqual(result, expected_result)
+
+    def test_dump_without_content(self):
+        result = Config.dump()
+        self.assertIsNone(result)

--- a/test/commands/test_config.py
+++ b/test/commands/test_config.py
@@ -32,7 +32,8 @@ class TestConfig(unittest.TestCase):
 
     def test_existing_file_in_home_directory(self):
         # GIVEN
-        Path.cwd().joinpath(self.filename).unlink(missing_ok=True)
+        if Path.cwd().joinpath(self.filename).exists():
+            Path.cwd().joinpath(self.filename).unlink()
         self.home_directory.joinpath(self.filename).touch()
         expected_path = self.home_directory.joinpath(self.filename)
         # WHEN
@@ -42,7 +43,8 @@ class TestConfig(unittest.TestCase):
 
     def test_file_not_found(self):
         # GIVEN
-        Path.cwd().joinpath(self.filename).unlink(missing_ok=True)
+        if Path.cwd().joinpath(self.filename).exists():
+            Path.cwd().joinpath(self.filename).unlink()
         shutil.rmtree(self.home_directory, ignore_errors=True)
         # WHEN
         actual = Config.locate()

--- a/test/fixtures/config.hcl
+++ b/test/fixtures/config.hcl
@@ -1,0 +1,30 @@
+nostr {
+    relays = [
+        "wss://nostr-pub.wellorder.net",
+        "wss://relay.damus.io",
+    ]
+
+    self {
+        name = "Ali Kiten"
+
+        nsec = "nsec1jqaxtwk4tymddju9dmn58tdxgwgl5ck23gg847fla9cyuslxklrq86fcjd"
+    }
+
+    receiver "Ray" {
+        name = "Ray Nostr"
+
+        npub = "npub1q75f9j9w4zzjf5978eh6ym3pewvrnq5p7tdpaf9anzqmvgkgz8ys22c62u"
+    }
+
+    listen "jon" {
+        name = "Jonathon Gate"
+
+        npub = "npub1s9c53smfq925qx6fgkqgw8as2e99l2hmj32gz0hjjhe8q67fxdvs3ga9je"
+    }
+
+    listen "jack" {
+        name = "Jack Hoose"
+
+        npub = "npub1s9c53smfq925qx6fgkqgw8as2e99l2hmj32gz0hjjhe8q67fxdvs3ga9je"
+    }
+}


### PR DESCRIPTION
### Feature

Load config for relays, self, receiver and listen to simplify the inputs for CLI

### TODO:
- [x] Use response to decouple Relay for the unit test;
- [x] Mock cwd and home path for config file unit test;